### PR TITLE
change Ping to properly handle GCR-like registries

### DIFF
--- a/registry/ping_test.go
+++ b/registry/ping_test.go
@@ -1,31 +1,94 @@
 package registry
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/docker/docker/api/types"
 )
 
-func TestPingable(t *testing.T) {
-	testcases := map[string]struct {
-		registry Registry
-		expect   bool
+func createClientAndPing(httpCode int, headerName string, headerValue string) (*Registry, func(), error) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(headerName, headerValue)
+		w.WriteHeader(httpCode)
+	}))
+
+	auth := types.AuthConfig{ServerAddress: ts.URL}
+	r, err := New(context.Background(), auth, Opt{Insecure: true})
+	return r, ts.Close, err
+}
+
+func TestPing(t *testing.T) {
+	testcases := []struct {
+		httpCode    int
+		headerName  string
+		headerValue string
+		wantErr     error
 	}{
-		"Docker": {
-			registry: Registry{URL: "https://registry-1.docker.io"},
-			expect:   true,
+		{
+			httpCode:    200,
+			headerName:  "whatever",
+			headerValue: "whatever",
+			wantErr:     ErrNoDockerHeader,
 		},
-		"GCR_global": {
-			registry: Registry{URL: "https://gcr.io"},
-			expect:   false,
+		{
+			httpCode:    401,
+			headerName:  "wrong",
+			headerValue: "whatever",
+			wantErr:     ErrNoDockerHeader,
 		},
-		"GCR_asia": {
-			registry: Registry{URL: "https://asia.gcr.io"},
-			expect:   false,
+		{
+			httpCode:    200,
+			headerName:  "docker-distribution-api-version",
+			headerValue: "registry/2.0",
+			wantErr:     nil,
+		},
+		{
+			httpCode:    401,
+			headerName:  "Docker-Distribution-API-Version",
+			headerValue: "registry/2.1",
+			// Many popular servers do allow unauthenticated image pulls, but require authentication to visit the base url.
+			// This conforms to Docker Registry v2 API Specification https://docs.docker.com/registry/spec/api/
+			// Thus `401 Unauthorized` is as good response as `200 OK`, if only it has the proper Docker header.
+			wantErr: nil,
 		},
 	}
-	for label, testcase := range testcases {
-		actual := testcase.registry.Pingable()
-		if testcase.expect != actual {
-			t.Fatalf("%s: expected (%v), got (%v)", label, testcase.expect, actual)
+	for _, tc := range testcases {
+		r, closeFunc, err := createClientAndPing(tc.httpCode, tc.headerName, tc.headerValue)
+		defer closeFunc()
+		if err != tc.wantErr {
+			t.Fatalf("when creating client and performing ping for (%v, %q, %q), got error %#v but expected %#v", tc.httpCode, tc.headerName, tc.headerValue, err, tc.wantErr)
+		}
+		if err != nil {
+			continue
+		}
+		err = r.Ping(context.Background())
+		if err != tc.wantErr {
+			t.Fatalf("when repeating ping for (%v, %q, %q), got error %#v but expected %#v", tc.httpCode, tc.headerName, tc.headerValue, err, tc.wantErr)
+		}
+	}
+}
+
+func TestPingable(t *testing.T) {
+	testcases := []struct {
+		registry Registry
+		want     bool
+	}{
+		{
+			registry: Registry{URL: "https://registry-1.docker.io"},
+			want:     true,
+		},
+		{
+			registry: Registry{URL: "https://asia.gcr.io"},
+			want:     true,
+		},
+	}
+	for _, testcase := range testcases {
+		got := testcase.registry.Pingable()
+		if testcase.want != got {
+			t.Fatalf("%s pingable: expected (%v), got (%v)", testcase.registry.URL, testcase.want, got)
 		}
 	}
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -26,13 +26,14 @@ var ErrUnexpectedHttpStatusCode = errors.New("unexpected http status code")
 
 // Registry defines the client for retrieving information from the registry API.
 type Registry struct {
-	URL      string
-	Domain   string
-	Username string
-	Password string
-	Client   *http.Client
-	Logf     LogfCallback
-	Opt      Opt
+	URL        string
+	Domain     string
+	Username   string
+	Password   string
+	Client     *http.Client
+	PingClient *http.Client
+	Logf       LogfCallback
+	Opt        Opt
 }
 
 var reProtocol = regexp.MustCompile("^https?://")
@@ -128,6 +129,13 @@ func newFromTransport(ctx context.Context, auth types.AuthConfig, transport http
 		Client: &http.Client{
 			Timeout:   opt.Timeout,
 			Transport: customTransport,
+		},
+		PingClient: &http.Client{
+			Timeout: opt.Timeout,
+			Transport: &CustomTransport{
+				Transport: transport,
+				Headers:   opt.Headers,
+			},
 		},
 		Username: auth.Username,
 		Password: auth.Password,

--- a/registry/tokentransport_test.go
+++ b/registry/tokentransport_test.go
@@ -14,6 +14,7 @@ import (
 func TestErrBasicAuth(t *testing.T) {
 	ctx := context.Background()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
 		if r.URL.Path == "/" {
 			w.Header().Set("www-authenticate", `Basic realm="Registry Realm",service="Docker registry"`)
 			w.WriteHeader(http.StatusUnauthorized)
@@ -44,6 +45,7 @@ func TestErrBasicAuth(t *testing.T) {
 var authURI string
 
 func oauthFlow(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
 	if strings.HasPrefix(r.URL.Path, "/oauth2/accesstoken") {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Change Registry.Ping() to:
  1. conform to the Docker specification by requiring header `Docker-Distribution-API-Version`
  2. respect http 401 response code as a responsive registry, but one for which caller is not completely authenticated (yet)

Change the `TokenTransport` unit tests to emit that header.

Inside `Registry.Pingable()` remove the naive workaround for GCR as the problem is now solved in a generic way. (Not only GCR was impacted by the problem by the way.)

I add separate `Registry.PingClient`, because the `Registry.Client` handles 401 by closing the body so it disables the possibility of distinguishing whether the 401 contained Docker-Distribution-API-Version header.